### PR TITLE
feat: implement feature request #23, move to thread-safe Queue

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-pylint==2.15.5
-mypy==0.990
+pylint==2.17.0
+mypy==1.1.1


### PR DESCRIPTION
feat: implement feature request #23, it's now possible to have an  allowlist or a denylist for devices
chore: big refactor/code cleanup
fix: use a threading-safe Queue for device events, fixing lots of edge-cases and concurrency issues, especially when offline_after was set to 1
chore!: remove polling and offline_after settings, they are no longer used with the new Queue mechanism