### PR TITLE
shell: fix params-listed devices stuck home after a fresh install/reinstall

### DIFF
--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -337,6 +337,32 @@ do_full_sync() {
 				fi
 			fi
 		done
+	else
+		# First-ever sync (fresh install, reinstall, or firmware upgrade): we
+		# have no history to diff against, so the block above can't detect
+		# "was home, now gone". Without this, a device that was marked home
+		# via a RETAINED MQTT message from a previous install stays stuck at
+		# home forever, since nothing ever tells HA otherwise.
+		#
+		# We can't discover arbitrary previously-tracked MACs from the router
+		# alone, but every MAC listed in params is a known, named device we
+		# can proactively check right now: if it's not in today's online
+		# list, publish it away immediately instead of waiting for a
+		# disassoc event (or the retire that never comes because it never
+		# reassociates while we're watching).
+		local now_macs
+		now_macs=$(awk '{print $2}' "$seen_file" | sort -u)
+		jsonfilter -i "$CONFIG" -e '@.params' 2>/dev/null | \
+			grep -oE '"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"' | tr -d '"' | tr 'A-Z' 'a-z' | sort -u | \
+			while read -r mac; do
+				[ -z "$mac" ] && continue
+				if ! echo "$now_macs" | grep -qx "$mac"; then
+					if should_handle_device "$mac"; then
+						ha_seen "$mac" 0
+						log "Device $mac is away (first sync, no prior state)" 1
+					fi
+				fi
+			done
 	fi
 
 	cp "$seen_file" "$LAST_SEEN"


### PR DESCRIPTION
### What
Fixes a bug in `presence-detector.sh`'s away-detection: on a fresh install, a
full reinstall, or after a router firmware upgrade that wipes `/usr` but not
the MQTT broker's retained state, a device that was previously `home` (via a
retained MQTT state message from a prior run) stays stuck `home` in Home
Assistant forever — nothing ever corrects it, because the device simply never
sends a fresh disassoc event if it's already absent when the script restarts.

### Why
`do_full_sync`'s away-detection only fires by diffing the current online list
against `$LAST_SEEN`, which doesn't exist yet on the very first sync after a
fresh start. Without prior history there's nothing to diff against, so
absent-but-previously-home devices are silently skipped.

### Fix
On the first-ever sync (no `$LAST_SEEN`), proactively check every MAC listed
in `params` — a known, named device we can query about immediately — against
the current online list, and publish it `away` right away if not connected.
This intentionally does not try to guess at un-named devices with no history,
since the router has no way to know about those until they first associate.

### How I found and verified it
Hit this for real: after an OpenWrt firmware upgrade wiped `/usr` on one of my
routers, I reinstalled the script and reconnected everything, but a phone that
was legitimately not connected stayed stuck `home` in Home Assistant. Traced
it to the missing `$LAST_SEEN` file on the fresh install. After the fix, a
fresh restart (with the runtime state directory wiped to force a genuine
first-ever sync) correctly published `not_home` for every params-listed
device not currently online, confirmed both in the router's log and in Home
Assistant's entity state.