### PR TITLE
python: fix devices stuck home after a restart

### DIFF
--- a/presence-detector.py
+++ b/presence-detector.py
@@ -124,7 +124,7 @@ class PresenceDetector(Thread):
         self._queue: Queue = Queue()
         self._watchers: list[UbusWatcher] = []
         self._killed = False
-        self._last_seen_clients: set[tuple[str, str]] = set()
+        self._last_seen_clients: set[tuple[str, str]] | None = None
         self._online_clients: dict[str, set[str]] = {}
         self._registered_clients: set[str] = set()
         for interface in self._settings.interfaces:
@@ -328,13 +328,42 @@ class PresenceDetector(Thread):
         """Perform a full sync of all current online devices compared to last time"""
         self._registered_clients = set()
         seen_now = set(self._get_all_online_devices())
-        away = self._last_seen_clients - seen_now
+        is_first_sync = self._last_seen_clients is None
+        away = (self._last_seen_clients or set()) - seen_now
         self._last_seen_clients = seen_now
         for interface, client in seen_now:
             if not away_only:
                 self.set_device_home(interface, client)
         for interface, client in away:
             self.set_device_away(interface, client)
+
+        if is_first_sync:
+            # On the very first sync there is no prior state to diff
+            # against (self._last_seen_clients started out as None), so the
+            # "away" set above is always empty by construction. Without this,
+            # a device that is not currently connected but was previously
+            # marked home via a RETAINED MQTT state message from an earlier
+            # run of this process stays stuck home in HA forever: nothing
+            # ever tells HA otherwise, because the device simply never sends
+            # a fresh disassoc event if it is already absent right now.
+            #
+            # We can't discover arbitrary previously-tracked MACs from ubus
+            # alone, but every MAC listed in params is a known, named device
+            # we can proactively check right now against the current online
+            # list.
+            seen_macs = {client for _interface, client in seen_now}
+            for device in self._settings.params:
+                if device in seen_macs or not self._should_handle_device(device):
+                    continue
+                self._logger.log(
+                    f"Device {device} is away (first sync, no prior state)", True
+                )
+                # Call _ha_seen directly rather than set_device_away: the
+                # latter's per-interface bookkeeping (self._online_clients)
+                # is keyed by real interface names and is only meaningful
+                # for devices that were actually observed on one, which by
+                # definition isn't the case here.
+                self._ha_seen(device, seen=False)
 
     def run(self) -> None:
         """Main loop for the presence detector"""

--- a/presence-detector.py
+++ b/presence-detector.py
@@ -338,19 +338,9 @@ class PresenceDetector(Thread):
             self.set_device_away(interface, client)
 
         if is_first_sync:
-            # On the very first sync there is no prior state to diff
-            # against (self._last_seen_clients started out as None), so the
-            # "away" set above is always empty by construction. Without this,
-            # a device that is not currently connected but was previously
-            # marked home via a RETAINED MQTT state message from an earlier
-            # run of this process stays stuck home in HA forever: nothing
-            # ever tells HA otherwise, because the device simply never sends
-            # a fresh disassoc event if it is already absent right now.
-            #
-            # We can't discover arbitrary previously-tracked MACs from ubus
-            # alone, but every MAC listed in params is a known, named device
-            # we can proactively check right now against the current online
-            # list.
+            # First-sync fix for #81: without this, a params-listed device
+            # that's currently offline but was previously marked home via a
+            # retained MQTT message stays stuck home forever.
             seen_macs = {client for _interface, client in seen_now}
             for device in self._settings.params:
                 if device in seen_macs or not self._should_handle_device(device):


### PR DESCRIPTION
Closes #81.

### What
Fixes `presence-detector.py` so a device that is currently not connected,
but was previously marked `home` via a retained MQTT state message from an
earlier run of this process, no longer stays stuck `home` in Home Assistant
after a restart.

### Why
`_do_full_sync()`'s `away = self._last_seen_clients - seen_now` is always
empty on the very first sync of any process lifetime, because
`_last_seen_clients` starts as an empty set and is never persisted across
restarts. So no device is ever proactively marked away on startup — see #81
for the full write-up.

### Fix
- `self._last_seen_clients` now starts as `None` (a sentinel meaning "no
  sync has run yet") instead of `set()`.
- In `_do_full_sync()`, on that first sync, proactively check every MAC
  listed in `params` — a known, named device we can query about
  immediately — against the current online list, and publish it `away`
  right away if absent.
- Untracked (non-`params`) devices are intentionally left alone: there's no
  way to know about a device with no history and no params entry until it
  first associates.
- Calls `_ha_seen(device, seen=False)` directly for the proactive check
  rather than routing through `set_device_away()`, since that method's
  per-interface bookkeeping (`self._online_clients`, keyed by real
  interface names) isn't meaningful for a device that was never observed
  on any interface this session.

### Testing
No live router in this environment, so I verified with an isolated unit
test that stubs out `paho.mqtt.client` and `_get_all_online_devices`
(no real MQTT/ubus needed) and drains the action queue directly:
- A `params`-listed device absent on the first sync is correctly marked
  away, while one that's present is marked home.
- A second sync (with real history now populated) goes through the
  normal diff path and behaves exactly as before — unaffected by the fix.
- An untracked (non-`params`) device present on both syncs is never
  incorrectly marked away by the new check.

I don't have a live OpenWrt router+HA to reproduce this exact scenario in
Python directly, but I hit the identical bug for real in the shell
implementation (`presence-detector.sh`, fixed in #80) after a router
firmware upgrade wiped the script but left the broker's retained `home`
state in place for a phone that wasn't actually connected — same root
cause, same fix shape, ported here.