### PR TITLE
shell: retain the discovery config, not just state

### DIFF
--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -337,6 +337,32 @@ do_full_sync() {
 				fi
 			fi
 		done
+	else
+		# First-ever sync (fresh install, reinstall, or firmware upgrade): we
+		# have no history to diff against, so the block above can't detect
+		# "was home, now gone". Without this, a device that was marked home
+		# via a RETAINED MQTT message from a previous install stays stuck at
+		# home forever, since nothing ever tells HA otherwise.
+		#
+		# We can't discover arbitrary previously-tracked MACs from the router
+		# alone, but every MAC listed in params is a known, named device we
+		# can proactively check right now: if it's not in today's online
+		# list, publish it away immediately instead of waiting for a
+		# disassoc event (or the retire that never comes because it never
+		# reassociates while we're watching).
+		local now_macs
+		now_macs=$(awk '{print $2}' "$seen_file" | sort -u)
+		jsonfilter -i "$CONFIG" -e '@.params' 2>/dev/null | \
+			grep -oE '"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"' | tr -d '"' | tr 'A-Z' 'a-z' | sort -u | \
+			while read -r mac; do
+				[ -z "$mac" ] && continue
+				if ! echo "$now_macs" | grep -qx "$mac"; then
+					if should_handle_device "$mac"; then
+						ha_seen "$mac" 0
+						log "Device $mac is away (first sync, no prior state)" 1
+					fi
+				fi
+			done
 	fi
 
 	cp "$seen_file" "$LAST_SEEN"

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -253,7 +253,14 @@ ha_seen() {
 			body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",${name_field}${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
 		fi
 
-		mqtt_pub "$config_topic" "$body"
+		# Retain the discovery config, not just state. Without this, if HA
+		# is offline/restarting at the exact moment this one-shot config
+		# message is published, HA has no way to learn about the entity's
+		# MQTT subscription again until this script itself restarts (which
+		# forces a fresh republish via reset_registrations). A retained
+		# config lets HA's MQTT integration pick the entity back up on its
+		# own reconnect.
+		mqtt_pub "$config_topic" "$body" 1
 		ok=$?
 	fi
 


### PR DESCRIPTION
Note: this branch is built on top of #80 (not yet merged), so the diff
against `main` includes both fixes. Once #80 merges I'll rebase this to
show only the new change; reviewing #80 first will make this diff trivial
(just the retain-flag addition described below).

### What
Retains the MQTT discovery config, not just the state, when publishing a
device_tracker entity.

### Why
Both this implementation and the Python original publish the discovery
`config` message without the retain flag. If Home Assistant is offline or
mid-restart at the exact moment that one-shot config message is published,
HA has no way to learn about the entity's MQTT subscription again — it
never gets a `config` message a second time — until the daemon itself
restarts (which forces a fresh republish via `reset_registrations` on the
next full sync).

I hit this for real: an entity was stuck `unavailable` in Home Assistant
(with `restored: true`, meaning HA loaded it from its own database at
startup but never resubscribed to the live MQTT topic) despite the router
continuously publishing correct `home`/`not_home` state the entire time —
the state messages simply had nowhere registered to land on the HA side.

### Fix
Pass the retain flag on the config publish, same as the state publish
already does.

### Tradeoff (already accepted elsewhere in this codebase)
Retaining config means a device later removed from `params` or added to
the `filter` denylist leaves a retained config behind on the broker. This
is the same staleness tradeoff the state topic already has (it's retained
too), and is already handled the same way — manually clearing the
retained topic when a device is deliberately untracked. This doesn't
introduce a new category of risk, just extends the existing one from
state to config.

### Verified
- Deployed to a router with a real stuck-`unavailable` entity; the
  discovery config for it is now retained on the broker (confirmed via
  `mosquitto_sub --retained-only`).
- Forcing a resync (the daemon-restart equivalent of what should now
  happen automatically on an HA reconnect) correctly re-established the
  live subscription and the entity now shows `home` again.
- No regression: friendly names, icons, and the doubled-name fix from #78
  are all unaffected.