### PR TITLE
shell: recommend mosquitto-client-nossl explicitly (fixes #85)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 presence-detector.settings.json
+presence-detector.settings.*.json
+!presence-detector.settings.*.json.example
 .idea/
 venv/

--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -1,0 +1,238 @@
+# Lightweight (shell) presence detector
+
+> **About this fork.** This is a fork of
+> [rmoesbergen/openwrt-ha-device-tracker](https://github.com/rmoesbergen/openwrt-ha-device-tracker).
+> All original credit for the design, the MQTT/discovery protocol, and the
+> Python implementation goes to the upstream author. This fork **adds one
+> thing**: `presence-detector.sh`, a pure-shell reimplementation for routers
+> too small to run Python (see below). The upstream `presence-detector.py`,
+> its README, and the settings format are kept intact and unchanged so the two
+> implementations stay interchangeable. Fixes to shared behavior are offered
+> back upstream where they apply.
+
+`presence-detector.sh` is a pure POSIX shell (ash/busybox) rewrite of
+`presence-detector.py`. It provides the **same functionality** and is a
+**drop-in replacement on the Home Assistant side** (identical MQTT topics,
+discovery config and state payloads), but uses a tiny fraction of the flash
+storage.
+
+Use this version if your router has limited free space and you cannot install
+Python and its dependencies (e.g. small 8/16 MB devices).
+
+## Why it's smaller
+
+The Python version needs `python3-light` plus several Python packages
+(`python3-paho-mqtt`, `python3-codecs`, `python3-urllib`, `python3-logging`),
+which together take roughly **5–10 MB** of flash.
+
+The shell version needs only:
+
+| Dependency         | Notes                                                        |
+|--------------------|--------------------------------------------------------------|
+| `mosquitto-client` | Provides `mosquitto_pub` / `mosquitto_sub` (~50–150 KB)      |
+| `jsonfilter`       | Part of base OpenWRT — used to parse the settings file       |
+| `ubus`             | Part of base OpenWRT                                         |
+| `logger`, `grep`, `tr`, `awk`, `sort` | All provided by busybox (already present) |
+
+In practice this is around **100–200 KB** instead of several megabytes, and
+`jsonfilter`/`ubus`/busybox are already installed on every OpenWRT system.
+
+## How it works
+
+The behavior mirrors the Python version:
+
+* On start it performs a **full sync** via `ubus call <iface> get_clients` and
+  publishes `home` for every connected client.
+* It runs one **`ubus subscribe <iface>`** watcher per Wi-Fi interface and
+  reacts to `assoc` (join) and `disassoc` (leave) events in realtime.
+* It subscribes to **`homeassistant/status`** and performs a full re-sync when
+  Home Assistant comes back online, and clears its registration cache when HA
+  goes offline (so devices get re-announced via MQTT discovery).
+* An optional **`fallback_sync_interval`** triggers a periodic full sync.
+
+Registration state (which devices have already had their discovery config
+published) is tracked with marker files under `/var/run/presence-detector/`,
+so the asynchronous watchers and the main loop share state without threads.
+
+## Installation
+
+On your OpenWRT device:
+
+1. Install the only extra dependency:
+   ```bash
+   opkg update && opkg install mosquitto-client
+   # or, on apk-based OpenWRT (snapshot):
+   # apk update && apk add mosquitto-client
+   ```
+   (`jsonfilter` and `ubus` are already part of the base system.)
+
+2. Copy `presence-detector.sh` and your settings file to a persistent location
+   (e.g. `/etc/config`). Start from the provided example and fill in your own
+   MQTT credentials:
+   ```bash
+   cp presence-detector.sh /etc/config/presence-detector.sh
+   cp presence-detector.settings.json.example /etc/config/presence-detector.settings.json
+   # then edit /etc/config/presence-detector.settings.json (set mqtt_password, etc.)
+   chmod +x /etc/config/presence-detector.sh
+   ```
+
+3. Install the init script (renamed to the standard service name):
+   ```bash
+   cp init.d/presence-detector-sh /etc/init.d/presence-detector
+   chmod +x /etc/init.d/presence-detector
+   ```
+
+4. Adjust `/etc/config/presence-detector.settings.json` to your needs — the
+   format is **identical** to the Python version. See the
+   [main README](README.md#openwrt-device-configuration) for a full
+   description of every setting.
+
+5. Enable and start the service:
+   ```bash
+   service presence-detector enable
+   service presence-detector start
+   ```
+   (or simply reboot).
+
+The Home Assistant side is unchanged — see
+[Steps to perform in Home Assistant](README.md#steps-to-perform-in-home-assistant).
+
+## Settings
+
+The settings file is the same `presence-detector.settings.json` used by the
+Python version. A sanitized template ships as
+[`presence-detector.settings.json.example`](presence-detector.settings.json.example) —
+copy it and fill in your own values. **Never commit a settings file
+containing your real `mqtt_password`** (the repo's `.gitignore` already
+excludes `presence-detector.settings.json` and
+`presence-detector.settings.*.json`). All settings are supported:
+
+`mqtt_host`, `mqtt_port`, `mqtt_username`, `mqtt_password`,
+`mqtt_retain_state`, `interfaces`, `filter_is_denylist`, `filter`, `params`,
+`ap_name`, `location`, `away`, `fallback_sync_interval`, `source_type`,
+`debug`.
+
+Notes / minor differences:
+
+* **`params`**: The shell version reads the per-device `name` and `icon`
+  overrides (the two commonly used keys). If you need to pass through other
+  arbitrary discovery keys, use the Python version — the shell version keeps
+  the params handling deliberately simple to stay small.
+* **`interfaces`**: As with the Python version, leave empty (`[]`) to
+  auto-detect all `hostapd.*` interfaces.
+* **`ap_name`**: Prefixes the entity — both its `unique_id`/MQTT topic **and**
+  its name — with the AP name (e.g. `device_tracker.cocina_aa_bb_...`). Leave
+  as `""` for a single access point. Set a **distinct** value per AP when
+  running on multiple access points (see
+  [Multiple access points & roaming](#multiple-access-points--roaming)).
+* **`debug`**: When `true`, debug lines are written to syslog (`logread`).
+
+## Multiple access points & roaming
+
+If you run this on several APs (e.g. one per floor/room) and the same phones
+roam through the house, follow this pattern so a device that moves between APs
+stays reliably "home".
+
+### Give each AP a distinct `ap_name`
+
+Set a **different** `ap_name` on every router:
+
+```jsonc
+// cocina router
+{ "ap_name": "cocina",     "...": "..." }
+// living-room router
+{ "ap_name": "livingroom", "...": "..." }
+// bedroom router
+{ "ap_name": "bedroom",    "...": "..." }
+```
+
+The same phone MAC then produces **one entity per AP**, all distinct:
+
+```
+device_tracker.cocina_54_32_04_3d_b4_c8
+device_tracker.livingroom_54_32_04_3d_b4_c8
+device_tracker.bedroom_54_32_04_3d_b4_c8
+```
+
+Because every tracker carries the same `device.connections` MAC, Home Assistant
+groups all three under a **single device** per phone — while keeping them as
+separate tracker entities (distinct `unique_id`s).
+
+> **Do not use `params` name overrides in a multi-AP setup.** If all APs give
+> the same MAC the same friendly name, HA cannot derive distinct entity IDs and
+> will append numeric suffixes (`..._2`, `..._3`). Leave the auto
+> `<ap>_<mac>` naming in place and give devices a human-friendly identity via a
+> Person (below).
+
+### Why not one shared entity across APs?
+
+It is tempting to leave `ap_name` empty on all APs so they publish to the *same*
+topic (one entity per MAC). **Don't** — it creates a race on roaming: when a
+phone moves from `cocina` to `livingroom`, `livingroom` publishes `home` while
+`cocina` publishes `not_home` for the same entity. Depending on ordering, the
+stale `not_home` can win and the device flips away even though it is connected.
+Each router only knows its own clients, so they cannot resolve this between
+themselves.
+
+### Combine per person with a Person entity (recommended)
+
+Home Assistant's **Person** entity is the built-in, roaming-safe combiner: a
+Person is `home` if **any** of its assigned device_trackers is home. Assign all
+of a person's per-AP trackers to their Person:
+
+* Settings → People → *(person)* → **"Select the devices that belong to this
+  person"** → add `device_tracker.cocina_<mac>`,
+  `device_tracker.livingroom_<mac>`, `device_tracker.bedroom_<mac>`.
+
+As the phone roams, whichever AP currently sees it keeps the Person `home`,
+absorbing the per-AP `assoc`/`disassoc` race. Base your automations on
+`person.<name>` instead of the individual trackers.
+
+> A `device_tracker` **group helper** is *not* available in Home Assistant
+> (the group helper only supports `binary_sensor`, `light`, `switch`, etc.), so
+> the Person entity — or a template `binary_sensor` that is `on` when any AP
+> tracker is `home` — is the correct way to OR the per-AP trackers.
+
+### Adding a new AP later
+
+1. Install `mosquitto-client` and the service on the new router (same steps as
+   [Installation](#installation)).
+2. Use a settings file identical to your other APs but with a new `ap_name`.
+3. Start the service; the new `device_tracker.<newap>_<mac>` entities appear.
+4. In HA, add each new tracker to the relevant Person.
+
+## Running manually / debugging
+
+You can run it in the foreground to watch what it does:
+
+```bash
+/etc/config/presence-detector.sh -c /etc/config/presence-detector.settings.json
+```
+
+Log output goes to syslog; read it with:
+
+```bash
+logread -e presence-detector
+```
+
+With `"debug": true` you will see lines like:
+
+```text
+daemon.debug presence-detector[1234]: Publishing to homeassistant/device_tracker/xx_xx_xx_xx_xx_xx/state: {"in_zones":["zone.home"],"state":"home"}
+```
+
+## Choosing between the shell and Python versions
+
+| | `presence-detector.sh` (shell) | `presence-detector.py` (Python) |
+|---|---|---|
+| Flash usage | ~100–200 KB (+ base tools) | ~5–10 MB (Python + deps) |
+| Dependencies | `mosquitto-client` | `python3-light`, `python3-paho-mqtt`, … |
+| Realtime events | ✅ `ubus subscribe` | ✅ `ubus subscribe` |
+| MQTT auto-discovery | ✅ | ✅ |
+| HA online/offline recovery | ✅ | ✅ |
+| Fallback periodic sync | ✅ | ✅ |
+| Arbitrary `params` passthrough | `name` + `icon` only | Any discovery key |
+
+For most single/dual-radio access points the shell version is fully
+equivalent. Pick the Python version only if you rely on advanced `params`
+passthrough.

--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -120,11 +120,13 @@ Notes / minor differences:
   the params handling deliberately simple to stay small.
 * **`interfaces`**: As with the Python version, leave empty (`[]`) to
   auto-detect all `hostapd.*` interfaces.
-* **`ap_name`**: Prefixes the entity — both its `unique_id`/MQTT topic **and**
-  its name — with the AP name (e.g. `device_tracker.cocina_aa_bb_...`). Leave
-  as `""` for a single access point. Set a **distinct** value per AP when
+* **`ap_name`**: Prefixes the entity's **`unique_id` and MQTT topic** with the
+  AP name (e.g. topic `homeassistant/device_tracker/cocina_aa_bb_.../state`,
+  `unique_id: cocina_aa_bb_...`). It does **not** change the friendly `name`.
+  Leave as `""` for a single access point; set a **distinct** value per AP when
   running on multiple access points (see
-  [Multiple access points & roaming](#multiple-access-points--roaming)).
+  [Multiple access points & roaming](#multiple-access-points--roaming)). This
+  matches the upstream Python behavior exactly.
 * **`debug`**: When `true`, debug lines are written to syslog (`logread`).
 
 ## Multiple access points & roaming
@@ -146,23 +148,37 @@ Set a **different** `ap_name` on every router:
 { "ap_name": "bedroom",    "...": "..." }
 ```
 
-The same phone MAC then produces **one entity per AP**, all distinct:
+`ap_name` prefixes the **`unique_id` and MQTT topic** only, so the same phone
+MAC produces **one entity per AP**, each with a distinct registry identity:
 
 ```
-device_tracker.cocina_54_32_04_3d_b4_c8
-device_tracker.livingroom_54_32_04_3d_b4_c8
-device_tracker.bedroom_54_32_04_3d_b4_c8
+unique_id: cocina_54_32_04_3d_b4_c8
+unique_id: livingroom_54_32_04_3d_b4_c8
+unique_id: bedroom_54_32_04_3d_b4_c8
 ```
 
 Because every tracker carries the same `device.connections` MAC, Home Assistant
 groups all three under a **single device** per phone — while keeping them as
-separate tracker entities (distinct `unique_id`s).
+three separate tracker entities. The `ap_name` prefix on the `unique_id` is
+what keeps those three from colliding; the friendly `name` is left untouched.
 
-> **Do not use `params` name overrides in a multi-AP setup.** If all APs give
-> the same MAC the same friendly name, HA cannot derive distinct entity IDs and
-> will append numeric suffixes (`..._2`, `..._3`). Leave the auto
-> `<ap>_<mac>` naming in place and give devices a human-friendly identity via a
-> Person (below).
+### A note on entity IDs (you can ignore them)
+
+Home Assistant derives a tracker's **`entity_id` from its friendly `name`**,
+not from the `unique_id`. So if you give the same MAC a friendly name via
+`params` (e.g. `"name": "Celu de Alfre"`), all three AP entities want the same
+`entity_id` and HA disambiguates them with numeric suffixes
+(`device_tracker.celu_de_alfre`, `..._2`, `..._3`). Which AP gets which suffix
+is not predictable.
+
+**That is fine — you never reference these per-AP entity IDs directly.** They
+are plumbing. You combine them via the device / Person (below) and build
+automations on the Person. Feel free to set friendly names and icons in
+`params`; the harmless `_2`/`_3` suffixes on the underlying entities don't
+matter.
+
+(If you leave `params` empty, the entities are simply named by MAC —
+`device_tracker.54_32_04_3d_b4_c8` etc. — which are already distinct.)
 
 ### Why not one shared entity across APs?
 
@@ -172,7 +188,8 @@ phone moves from `cocina` to `livingroom`, `livingroom` publishes `home` while
 `cocina` publishes `not_home` for the same entity. Depending on ordering, the
 stale `not_home` can win and the device flips away even though it is connected.
 Each router only knows its own clients, so they cannot resolve this between
-themselves.
+themselves. Keeping a distinct `ap_name` per AP (so each publishes its own
+entity) plus combining in HA avoids the race entirely.
 
 ### Combine per person with a Person entity (recommended)
 
@@ -181,12 +198,12 @@ Person is `home` if **any** of its assigned device_trackers is home. Assign all
 of a person's per-AP trackers to their Person:
 
 * Settings → People → *(person)* → **"Select the devices that belong to this
-  person"** → add `device_tracker.cocina_<mac>`,
-  `device_tracker.livingroom_<mac>`, `device_tracker.bedroom_<mac>`.
+  person"** → add that person's tracker from each AP.
 
-As the phone roams, whichever AP currently sees it keeps the Person `home`,
-absorbing the per-AP `assoc`/`disassoc` race. Base your automations on
-`person.<name>` instead of the individual trackers.
+Since all of a phone's per-AP trackers share one **device**, they are easy to
+find together in that list. As the phone roams, whichever AP currently sees it
+keeps the Person `home`, absorbing the per-AP `assoc`/`disassoc` race. Base
+your automations on `person.<name>` instead of the individual trackers.
 
 > A `device_tracker` **group helper** is *not* available in Home Assistant
 > (the group helper only supports `binary_sensor`, `light`, `switch`, etc.), so
@@ -198,7 +215,8 @@ absorbing the per-AP `assoc`/`disassoc` race. Base your automations on
 1. Install `mosquitto-client` and the service on the new router (same steps as
    [Installation](#installation)).
 2. Use a settings file identical to your other APs but with a new `ap_name`.
-3. Start the service; the new `device_tracker.<newap>_<mac>` entities appear.
+3. Start the service; a new tracker entity for each phone appears under that
+   phone's existing device (one more tracker per device).
 4. In HA, add each new tracker to the relevant Person.
 
 ## Running manually / debugging

--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -66,15 +66,18 @@ On your OpenWRT device:
    ```
    (`jsonfilter` and `ubus` are already part of the base system.)
 
-2. Copy `presence-detector.sh` and your settings file to a persistent location
-   (e.g. `/etc/config`). Start from the provided example and fill in your own
-   MQTT credentials:
+2. Install the executable to `/usr/bin` (executables belong here, not in
+   `/etc/config`), and copy the settings file into `/etc/config`. Start from
+   the provided example and fill in your own MQTT credentials:
    ```bash
-   cp presence-detector.sh /etc/config/presence-detector.sh
+   cp presence-detector.sh /usr/bin/presence-detector.sh
+   chmod +x /usr/bin/presence-detector.sh
    cp presence-detector.settings.json.example /etc/config/presence-detector.settings.json
    # then edit /etc/config/presence-detector.settings.json (set mqtt_password, etc.)
-   chmod +x /etc/config/presence-detector.sh
    ```
+   The script looks for its settings at
+   `/etc/config/presence-detector.settings.json` by default; override with
+   `-c /path/to/settings.json` if you keep it elsewhere.
 
 3. Install the init script (renamed to the standard service name):
    ```bash
@@ -224,7 +227,7 @@ your automations on `person.<name>` instead of the individual trackers.
 You can run it in the foreground to watch what it does:
 
 ```bash
-/etc/config/presence-detector.sh -c /etc/config/presence-detector.settings.json
+/usr/bin/presence-detector.sh -c /etc/config/presence-detector.settings.json
 ```
 
 Log output goes to syslog; read it with:

--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -29,7 +29,7 @@ The shell version needs only:
 
 | Dependency         | Notes                                                        |
 |--------------------|--------------------------------------------------------------|
-| `mosquitto-client` | Provides `mosquitto_pub` / `mosquitto_sub` (~50–150 KB)      |
+| `mosquitto-client-nossl` | Provides `mosquitto_pub` / `mosquitto_sub` (~144 KiB; the `-ssl` alternative is ~216 KiB and unneeded — see [Installation](#installation)) |
 | `jsonfilter`       | Part of base OpenWRT — used to parse the settings file       |
 | `ubus`             | Part of base OpenWRT                                         |
 | `ucode`            | Base OpenWRT (22.03+) — optional; enables full `params` deep-merge (falls back to name+icon without it) |
@@ -59,13 +59,25 @@ so the asynchronous watchers and the main loop share state without threads.
 
 On your OpenWRT device:
 
-1. Install the only extra dependency:
+1. Install the only extra dependency. Use the **`-nossl`** variant explicitly
+   — this package ships as two alternatives (`mosquitto-client-nossl` and
+   `mosquitto-client-ssl`, ~144 KiB vs ~216 KiB installed), and the plain
+   `mosquitto-client` name is ambiguous between them. Which one it resolves
+   to isn't guaranteed, and on at least one very space-constrained device
+   the SSL variant got pulled in and caused an out-of-space install failure.
+   Since this script only ever talks to the broker in plain TCP (no `mqtts://`
+   / TLS), the SSL variant buys nothing here — always ask for `-nossl` by name:
    ```bash
-   opkg update && opkg install mosquitto-client
-   # or, on apk-based OpenWRT (snapshot):
-   # apk update && apk add mosquitto-client
+   opkg update && opkg install mosquitto-client-nossl
+   # or, on apk-based OpenWRT:
+   # apk update && apk add mosquitto-client-nossl
    ```
    (`jsonfilter` and `ubus` are already part of the base system.)
+
+   If you're building your own image (imagebuilder or Attended SysUpgrade
+   with advanced mode), you can bake `mosquitto-client-nossl` into the image
+   directly instead of installing it at runtime — one less write to the
+   overlay on a device where every KB counts.
 
 2. Install the executable to `/usr/bin` (executables belong here, not in
    `/etc/config`), and copy the settings file into `/etc/config`. Start from
@@ -230,7 +242,7 @@ your automations on `person.<name>` instead of the individual trackers.
 
 ### Adding a new AP later
 
-1. Install `mosquitto-client` and the service on the new router (same steps as
+1. Install `mosquitto-client-nossl` and the service on the new router (same steps as
    [Installation](#installation)).
 2. Use a settings file identical to your other APs but with a new `ap_name`.
 3. Start the service; a new tracker entity for each phone appears under that
@@ -262,7 +274,7 @@ daemon.debug presence-detector[1234]: Publishing to homeassistant/device_tracker
 | | `presence-detector.sh` (shell) | `presence-detector.py` (Python) |
 |---|---|---|
 | Flash usage | ~100–200 KB (+ base tools) | ~5–10 MB (Python + deps) |
-| Dependencies | `mosquitto-client` | `python3-light`, `python3-paho-mqtt`, … |
+| Dependencies | `mosquitto-client-nossl` | `python3-light`, `python3-paho-mqtt`, … |
 | Realtime events | ✅ `ubus subscribe` | ✅ `ubus subscribe` |
 | MQTT auto-discovery | ✅ | ✅ |
 | HA online/offline recovery | ✅ | ✅ |

--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -32,6 +32,7 @@ The shell version needs only:
 | `mosquitto-client` | Provides `mosquitto_pub` / `mosquitto_sub` (~50–150 KB)      |
 | `jsonfilter`       | Part of base OpenWRT — used to parse the settings file       |
 | `ubus`             | Part of base OpenWRT                                         |
+| `ucode`            | Base OpenWRT (22.03+) — optional; enables full `params` deep-merge (falls back to name+icon without it) |
 | `logger`, `grep`, `tr`, `awk`, `sort` | All provided by busybox (already present) |
 
 In practice this is around **100–200 KB** instead of several megabytes, and
@@ -117,10 +118,24 @@ excludes `presence-detector.settings.json` and
 
 Notes / minor differences:
 
-* **`params`**: The shell version reads the per-device `name` and `icon`
-  overrides (the two commonly used keys). If you need to pass through other
-  arbitrary discovery keys, use the Python version — the shell version keeps
-  the params handling deliberately simple to stay small.
+* **`params`**: On OpenWRT 22.03+ (where `ucode` is present) the **entire**
+  params block for a device is deep-merged into the MQTT discovery config, so
+  **any** key works — including nested `device` keys like `manufacturer`,
+  `model`, `sw_version`, `configuration_url`, etc. — matching the Python
+  version. Example:
+  ```json
+  "params": {
+    "a0:85:e3:c5:b5:a4": {
+      "name": "Fridge Plug",
+      "icon": "mdi:fridge",
+      "device": { "manufacturer": "Shelly", "model": "Plus Plug S" }
+    }
+  }
+  ```
+  On a minimal build **without `ucode`**, the script falls back to a
+  string-built config that supports only `name` + `icon` (it logs a note at
+  startup). Either way, when a device is named the entity name is emitted as
+  `null` so Home Assistant shows the name once rather than doubled.
 * **`interfaces`**: As with the Python version, leave empty (`[]`) to
   auto-detect all `hostapd.*` interfaces.
 * **`ap_name`**: Prefixes the entity's **`unique_id` and MQTT topic** with the
@@ -252,8 +267,8 @@ daemon.debug presence-detector[1234]: Publishing to homeassistant/device_tracker
 | MQTT auto-discovery | ✅ | ✅ |
 | HA online/offline recovery | ✅ | ✅ |
 | Fallback periodic sync | ✅ | ✅ |
-| Arbitrary `params` passthrough | `name` + `icon` only | Any discovery key |
+| Arbitrary `params` passthrough | ✅ with `ucode` (22.03+); name+icon on minimal builds | Any discovery key |
 
 For most single/dual-radio access points the shell version is fully
-equivalent. Pick the Python version only if you rely on advanced `params`
-passthrough.
+equivalent — including full `params` passthrough on OpenWRT 22.03+. Only on a
+minimal build without `ucode` does `params` narrow to `name` + `icon`.

--- a/init.d/presence-detector-sh
+++ b/init.d/presence-detector-sh
@@ -4,7 +4,7 @@ START=90
 STOP=1
 USE_PROCD=1
 NAME=presence-detector
-PROG=/etc/config/presence-detector.sh
+PROG=/usr/bin/presence-detector.sh
 
 start_service() {
 	procd_open_instance

--- a/init.d/presence-detector-sh
+++ b/init.d/presence-detector-sh
@@ -1,0 +1,17 @@
+#!/bin/sh /etc/rc.common
+
+START=90
+STOP=1
+USE_PROCD=1
+NAME=presence-detector
+PROG=/etc/config/presence-detector.sh
+
+start_service() {
+	procd_open_instance
+	procd_set_param command "$PROG"
+	procd_set_param stdout 1
+	procd_set_param stderr 1
+	procd_set_param respawn
+	procd_set_param term_timeout 30
+	procd_close_instance
+}

--- a/init.d/presence-detector-sh
+++ b/init.d/presence-detector-sh
@@ -12,6 +12,23 @@ start_service() {
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param respawn
-	procd_set_param term_timeout 30
+	procd_set_param term_timeout 10
 	procd_close_instance
+}
+
+# Explicit teardown. The daemon forks background watchers that block on
+# `ubus subscribe` / `mosquitto_sub` reads; relying solely on the script's
+# own SIGTERM trap is fragile (a blocked child can reparent to init and be
+# missed). This reap runs after procd signals the main process and removes
+# any stragglers by pattern so nothing leaks across restarts.
+stop_service() {
+	# Signal the script to stop (its watcher/main loops poll this flag).
+	touch /var/run/presence-detector/.stop 2>/dev/null
+	# Reap any leftover watcher grandchildren. busybox has pgrep, not pkill.
+	local pids
+	pids=$( { pgrep -f 'ubus subscribe hostapd'; pgrep -f 'mosquitto_sub.*homeassistant/status'; } 2>/dev/null | sort -u )
+	[ -n "$pids" ] && kill $pids 2>/dev/null
+	sleep 1
+	pids=$( { pgrep -f 'ubus subscribe hostapd'; pgrep -f 'mosquitto_sub.*homeassistant/status'; } 2>/dev/null | sort -u )
+	[ -n "$pids" ] && kill -9 $pids 2>/dev/null
 }

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -337,6 +337,32 @@ do_full_sync() {
 				fi
 			fi
 		done
+	else
+		# First-ever sync (fresh install, reinstall, or firmware upgrade): we
+		# have no history to diff against, so the block above can't detect
+		# "was home, now gone". Without this, a device that was marked home
+		# via a RETAINED MQTT message from a previous install stays stuck at
+		# home forever, since nothing ever tells HA otherwise.
+		#
+		# We can't discover arbitrary previously-tracked MACs from the router
+		# alone, but every MAC listed in params is a known, named device we
+		# can proactively check right now: if it's not in today's online
+		# list, publish it away immediately instead of waiting for a
+		# disassoc event (or the retire that never comes because it never
+		# reassociates while we're watching).
+		local now_macs
+		now_macs=$(awk '{print $2}' "$seen_file" | sort -u)
+		jsonfilter -i "$CONFIG" -e '@.params' 2>/dev/null | \
+			grep -oE '"[0-9a-fA-F]{2}(:[0-9a-fA-F]{2}){5}"' | tr -d '"' | tr 'A-Z' 'a-z' | sort -u | \
+			while read -r mac; do
+				[ -z "$mac" ] && continue
+				if ! echo "$now_macs" | grep -qx "$mac"; then
+					if should_handle_device "$mac"; then
+						ha_seen "$mac" 0
+						log "Device $mac is away (first sync, no prior state)" 1
+					fi
+				fi
+			done
 	fi
 
 	cp "$seen_file" "$LAST_SEEN"

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -1,0 +1,416 @@
+#!/bin/sh
+#
+# A lightweight Wi-Fi device presence detector for Home Assistant that runs on
+# OpenWRT. This is a pure POSIX/ash + busybox rewrite of presence-detector.py,
+# designed to minimize flash storage usage.
+#
+# Dependencies (OpenWRT packages):
+#   - mosquitto-client (provides mosquitto_pub / mosquitto_sub)
+#   - jsonfilter       (part of base OpenWRT, used to parse JSON)
+#   - ubus / ubusd     (part of base OpenWRT)
+#
+# It uses the exact same settings file and MQTT topic/payload format as the
+# Python version, so it is a drop-in replacement on the Home Assistant side.
+
+CONFIG="/etc/config/presence-detector.settings.json"
+
+log() {
+	# log <message> [is_debug]
+	# Only log debug messages when debugging is enabled.
+	if [ "$2" = "1" ] && [ "$DEBUG" != "1" ]; then
+		return
+	fi
+	local level="daemon.info"
+	[ "$2" = "1" ] && level="daemon.debug"
+	logger -t "presence-detector" -p "$level" "$1"
+}
+
+# ---------------------------------------------------------------------------
+# Settings handling
+# ---------------------------------------------------------------------------
+
+# Read a single scalar setting from the config file with a default fallback.
+# Usage: get_setting <json-path> <default>
+get_setting() {
+	local value
+	value=$(jsonfilter -i "$CONFIG" -e "$1" 2>/dev/null)
+	if [ -z "$value" ]; then
+		echo "$2"
+	else
+		echo "$value"
+	fi
+}
+
+# Read an array setting as newline-separated values.
+# Usage: get_array <json-path>
+get_array() {
+	jsonfilter -i "$CONFIG" -e "$1[*]" 2>/dev/null
+}
+
+load_settings() {
+	if [ ! -f "$CONFIG" ]; then
+		log "Config file $CONFIG not found!"
+		exit 1
+	fi
+
+	MQTT_HOST=$(get_setting '@.mqtt_host' '192.168.1.50')
+	MQTT_PORT=$(get_setting '@.mqtt_port' '1883')
+	MQTT_USERNAME=$(get_setting '@.mqtt_username' 'ha')
+	MQTT_PASSWORD=$(get_setting '@.mqtt_password' '')
+	MQTT_RETAIN_STATE=$(get_setting '@.mqtt_retain_state' 'true')
+	FILTER_IS_DENYLIST=$(get_setting '@.filter_is_denylist' 'true')
+	AP_NAME=$(get_setting '@.ap_name' '')
+	LOCATION=$(get_setting '@.location' 'home')
+	AWAY=$(get_setting '@.away' 'not_home')
+	FALLBACK_SYNC_INTERVAL=$(get_setting '@.fallback_sync_interval' '0')
+	SOURCE_TYPE=$(get_setting '@.source_type' 'router')
+	DEBUG=$(get_setting '@.debug' 'false')
+	[ "$DEBUG" = "true" ] && DEBUG=1 || DEBUG=0
+
+	# Filter list, lowercased
+	FILTER=$(get_array '@.filter' | tr 'A-Z' 'a-z')
+
+	# Interfaces: auto-detect if not specified
+	INTERFACES=$(get_array '@.interfaces')
+	if [ -z "$INTERFACES" ]; then
+		INTERFACES=$(ubus list 'hostapd.*' 2>/dev/null)
+	fi
+
+	if [ -z "$INTERFACES" ]; then
+		log "No wifi interfaces found or configured!"
+		exit 1
+	fi
+}
+
+# ---------------------------------------------------------------------------
+# MQTT helpers
+# ---------------------------------------------------------------------------
+
+mqtt_pub() {
+	# mqtt_pub <topic> <payload> [retain]
+	local topic="$1"
+	local payload="$2"
+	local retain_flag=""
+	[ "$3" = "1" ] && retain_flag="-r"
+
+	local auth=""
+	[ -n "$MQTT_USERNAME" ] && auth="-u $MQTT_USERNAME -P $MQTT_PASSWORD"
+
+	log "Publishing to $topic: $payload" 1
+	# shellcheck disable=SC2086
+	mosquitto_pub -h "$MQTT_HOST" -p "$MQTT_PORT" $auth \
+		-q 1 $retain_flag -t "$topic" -m "$payload"
+	return $?
+}
+
+# ---------------------------------------------------------------------------
+# Registration state
+# ---------------------------------------------------------------------------
+# We track which device slugs have already been registered (config published)
+# with marker files in a tmpfs runtime dir, so the async ubus watchers and the
+# main process share state without needing threads.
+
+RUNDIR="/var/run/presence-detector"
+LAST_SEEN="/var/run/presence-detector.last_seen"
+
+reset_registrations() {
+	# Only clears the registered-slug markers (forces re-publish of discovery
+	# config), NOT the last_seen tracking file or the .stop flag.
+	mkdir -p "$RUNDIR"
+	rm -f "$RUNDIR"/*.reg 2>/dev/null
+}
+
+is_registered() {
+	[ -f "$RUNDIR/$1.reg" ]
+}
+
+mark_registered() {
+	touch "$RUNDIR/$1.reg"
+}
+
+# ---------------------------------------------------------------------------
+# Device filtering
+# ---------------------------------------------------------------------------
+
+should_handle_device() {
+	# Returns 0 (true) if the device should be handled.
+	local device="$1"
+	local in_list=0
+	local mac
+	for mac in $FILTER; do
+		if [ "$mac" = "$device" ]; then
+			in_list=1
+			break
+		fi
+	done
+
+	if [ "$in_list" = "1" ]; then
+		# In list: handle only if it is an allowlist (denylist=false)
+		[ "$FILTER_IS_DENYLIST" = "true" ] && return 1 || return 0
+	fi
+	# Not in list: handle only if it is a denylist
+	[ "$FILTER_IS_DENYLIST" = "true" ] && return 0 || return 1
+}
+
+# ---------------------------------------------------------------------------
+# JSON escaping for params passthrough
+# ---------------------------------------------------------------------------
+
+# Publish the discovery config + state for a device.
+# ha_seen <device-mac> <seen: 1|0>
+ha_seen() {
+	local device="$1"
+	local seen="$2"
+
+	# device_slug: mac with ':' -> '_', optionally prefixed by ap_name
+	local device_name
+	device_name=$(echo "$device" | tr ':' '_')
+	local device_slug="$device_name"
+	if [ -n "$AP_NAME" ]; then
+		device_slug="${AP_NAME}_${device_name}"
+	fi
+
+	local ok=0
+
+	if ! is_registered "$device_slug"; then
+		mark_registered "$device_slug"
+
+		# Look up per-device overrides for name / icon from params.
+		local override_name
+		override_name=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].name" 2>/dev/null)
+		local override_icon
+		override_icon=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].icon" 2>/dev/null)
+
+		local name="$device_name"
+		[ -n "$AP_NAME" ] && name="${AP_NAME}_${device_name}"
+		[ -n "$override_name" ] && name="$override_name"
+
+		local device_block="\"connections\":[[\"mac\",\"$device\"]]"
+		if [ -n "$override_name" ]; then
+			device_block="$device_block,\"name\":\"$override_name\""
+		fi
+
+		local icon_field=""
+		[ -n "$override_icon" ] && icon_field="\"icon\":\"$override_icon\","
+
+		local config_topic="homeassistant/device_tracker/${device_slug}/config"
+		local state_topic="homeassistant/device_tracker/${device_slug}/state"
+		local body
+		body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",\"name\":\"$name\",${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
+
+		mqtt_pub "$config_topic" "$body"
+		ok=$?
+	fi
+
+	# Publish state
+	local state_topic="homeassistant/device_tracker/${device_slug}/state"
+	local state_payload
+	if [ "$seen" = "1" ]; then
+		state_payload="{\"in_zones\":[\"zone.$LOCATION\"],\"state\":\"$LOCATION\"}"
+	else
+		state_payload="{\"in_zones\":[],\"state\":\"$AWAY\"}"
+	fi
+
+	local retain=0
+	[ "$MQTT_RETAIN_STATE" = "true" ] && retain=1
+	mqtt_pub "$state_topic" "$state_payload" "$retain"
+	ok=$((ok + $?))
+
+	return $ok
+}
+
+# ---------------------------------------------------------------------------
+# Full sync
+# ---------------------------------------------------------------------------
+
+get_all_online_devices() {
+	# Prints "interface mac" pairs for every currently connected client.
+	local interface
+	for interface in $INTERFACES; do
+		ubus call "$interface" get_clients 2>/dev/null | \
+			grep -o '"[0-9a-fA-F:]\{17\}"' | tr -d '"' | tr 'A-Z' 'a-z' | \
+			sort -u | \
+			while read -r mac; do
+				[ -n "$mac" ] && echo "$interface $mac"
+			done
+	done
+}
+
+do_full_sync() {
+	# Re-register everything and publish current state for all online devices.
+	reset_registrations
+	local seen_file="$RUNDIR/.seen_now"
+	get_all_online_devices | sort -u > "$seen_file"
+
+	# Publish 'home' for everything currently online.
+	while read -r interface mac; do
+		[ -z "$mac" ] && continue
+		if should_handle_device "$mac"; then
+			ha_seen "$mac" 1
+			log "Device $mac on $interface is now at $LOCATION" 1
+		fi
+	done < "$seen_file"
+
+	# Any MAC in last_seen but no longer online is now away.
+	if [ -f "$LAST_SEEN" ]; then
+		# Compare on the MAC column only (a device may roam interfaces).
+		local now_macs
+		now_macs=$(awk '{print $2}' "$seen_file" | sort -u)
+		awk '{print $2}' "$LAST_SEEN" | sort -u | while read -r mac; do
+			[ -z "$mac" ] && continue
+			if ! echo "$now_macs" | grep -qx "$mac"; then
+				if should_handle_device "$mac"; then
+					ha_seen "$mac" 0
+					log "Device $mac is now away" 1
+				fi
+			fi
+		done
+	fi
+
+	cp "$seen_file" "$LAST_SEEN"
+}
+
+# ---------------------------------------------------------------------------
+# Event watchers
+# ---------------------------------------------------------------------------
+
+# Watch a single interface's ubus events and act on assoc/disassoc.
+watch_interface() {
+	local interface="$1"
+	while [ ! -f "$RUNDIR/.stop" ]; do
+		# ubus subscribe streams JSON events, one per line-ish.
+		ubus subscribe "$interface" 2>/dev/null | while read -r line; do
+			[ -f "$RUNDIR/.stop" ] && break
+			case "$line" in
+			*'"assoc"'*)
+				local mac
+				mac=$(echo "$line" | grep -o '"address":"[^"]*"' | \
+					head -n1 | cut -d'"' -f4 | tr 'A-Z' 'a-z')
+				[ -z "$mac" ] && continue
+				if should_handle_device "$mac"; then
+					log "Device $mac on $interface is now at $LOCATION" 1
+					ha_seen "$mac" 1
+				fi
+				;;
+			*'"disassoc"'*)
+				local mac
+				mac=$(echo "$line" | grep -o '"address":"[^"]*"' | \
+					head -n1 | cut -d'"' -f4 | tr 'A-Z' 'a-z')
+				[ -z "$mac" ] && continue
+				if should_handle_device "$mac"; then
+					log "Device $mac on $interface is now away" 1
+					ha_seen "$mac" 0
+				fi
+				;;
+			esac
+		done
+		# If ubus subscribe exits (interface gone), wait and retry.
+		[ -f "$RUNDIR/.stop" ] && break
+		sleep 5
+	done
+}
+
+# Watch Home Assistant status topic to re-sync when HA comes back online.
+watch_ha_status() {
+	local auth=""
+	[ -n "$MQTT_USERNAME" ] && auth="-u $MQTT_USERNAME -P $MQTT_PASSWORD"
+	while [ ! -f "$RUNDIR/.stop" ]; do
+		# shellcheck disable=SC2086
+		mosquitto_sub -h "$MQTT_HOST" -p "$MQTT_PORT" $auth \
+			-t "homeassistant/status" 2>/dev/null | while read -r payload; do
+			[ -f "$RUNDIR/.stop" ] && break
+			case "$payload" in
+			offline)
+				log "Home Assistant is offline!"
+				reset_registrations
+				;;
+			online)
+				log "Home Assistant is back online"
+				do_full_sync
+				;;
+			esac
+		done
+		[ -f "$RUNDIR/.stop" ] && break
+		sleep 5
+	done
+}
+
+# ---------------------------------------------------------------------------
+# Shutdown handling
+# ---------------------------------------------------------------------------
+
+cleanup() {
+	log "Stopping..."
+	touch "$RUNDIR/.stop" 2>/dev/null
+	trap '' TERM INT
+	# Kill the whole process group so that grandchildren spawned inside
+	# watcher pipes (ubus subscribe, mosquitto_sub) are terminated too, not
+	# just the direct background jobs.
+	kill $CHILD_PIDS 2>/dev/null
+	# Best-effort cleanup of the streaming subprocesses in case they were
+	# reparented (e.g. their parent pipe subshell already exited).
+	for interface in $INTERFACES; do
+		pkill -f "ubus subscribe $interface" 2>/dev/null
+	done
+	pkill -f "mosquitto_sub.*homeassistant/status" 2>/dev/null
+	sleep 1
+	kill -9 $CHILD_PIDS 2>/dev/null
+	exit 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	# Parse -c/--config argument
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		-c|--config)
+			CONFIG="$2"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	load_settings
+	reset_registrations
+	trap cleanup TERM INT
+
+	log "Starting presence-detector on interfaces: $INTERFACES"
+
+	# Initial full sync
+	do_full_sync
+
+	CHILD_PIDS=""
+
+	# Start HA status watcher
+	watch_ha_status &
+	CHILD_PIDS="$CHILD_PIDS $!"
+
+	# Start a watcher per interface
+	local interface
+	for interface in $INTERFACES; do
+		watch_interface "$interface" &
+		CHILD_PIDS="$CHILD_PIDS $!"
+	done
+
+	# Main loop: perform periodic fallback full sync if configured.
+	while [ ! -f "$RUNDIR/.stop" ]; do
+		if [ "$FALLBACK_SYNC_INTERVAL" -gt 0 ] 2>/dev/null; then
+			sleep "$FALLBACK_SYNC_INTERVAL"
+			[ -f "$RUNDIR/.stop" ] && break
+			do_full_sync
+		else
+			sleep 3600 &
+			wait $!
+		fi
+	done
+
+	cleanup
+}
+
+main "$@"

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -359,11 +359,13 @@ cleanup() {
 	log "Stopping..."
 	touch "$RUNDIR/.stop" 2>/dev/null
 	trap '' TERM INT
-	# Kill the direct background jobs (the watcher subshells).
+	# Kill the direct background jobs (the watcher subshells)...
 	kill $CHILD_PIDS 2>/dev/null
-	# Also kill the streaming grandchildren (ubus subscribe / mosquitto_sub)
-	# spawned inside the watcher pipes. busybox has `pgrep` but NOT `pkill`,
-	# so find PIDs with pgrep and kill them explicitly.
+	# ...and the streaming grandchildren (ubus subscribe / mosquitto_sub)
+	# spawned inside the watcher pipes, which may have reparented to init.
+	# busybox has `pgrep` but NOT `pkill`, so match PIDs and kill them.
+	# (The init.d stop_service performs the same reap independently, so
+	# teardown does not rely on this trap firing.)
 	local gp
 	for interface in $INTERFACES; do
 		gp=$(pgrep -f "ubus subscribe $interface" 2>/dev/null)
@@ -372,7 +374,6 @@ cleanup() {
 	gp=$(pgrep -f "mosquitto_sub.*homeassistant/status" 2>/dev/null)
 	[ -n "$gp" ] && kill $gp 2>/dev/null
 	sleep 1
-	# Force any survivors.
 	kill -9 $CHILD_PIDS 2>/dev/null
 	for interface in $INTERFACES; do
 		gp=$(pgrep -f "ubus subscribe $interface" 2>/dev/null)
@@ -436,13 +437,22 @@ main() {
 	# background watcher children exit/respawn they deliver SIGCHLD, which
 	# interrupts `wait` and would spin this loop (and destabilise the procd
 	# instance). A plain foreground `sleep` is not affected by SIGCHLD.
+	#
+	# We poll in short (2s) increments rather than one long sleep so that a
+	# stop is noticed almost immediately: init.d stop_service writes the
+	# .stop flag, and we exit on the next tick and run cleanup — without
+	# depending on a SIGTERM trap interrupting a long `sleep` (unreliable on
+	# busybox ash), and well within procd's term_timeout.
+	local elapsed=0
 	while [ ! -f "$RUNDIR/.stop" ]; do
+		sleep 2
 		if [ "$FALLBACK_SYNC_INTERVAL" -gt 0 ] 2>/dev/null; then
-			sleep "$FALLBACK_SYNC_INTERVAL"
-			[ -f "$RUNDIR/.stop" ] && break
-			do_full_sync
-		else
-			sleep 3600
+			elapsed=$((elapsed + 2))
+			if [ "$elapsed" -ge "$FALLBACK_SYNC_INTERVAL" ]; then
+				elapsed=0
+				[ -f "$RUNDIR/.stop" ] && break
+				do_full_sync
+			fi
 		fi
 	done
 

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -301,13 +301,18 @@ get_all_online_devices() {
 do_full_sync() {
 	# Re-register everything and publish current state for all online devices.
 	#
+	# force=1 bypasses the debounce below. Used when we know we may have
+	# missed events (e.g. a watcher just reconnected after an unexpected
+	# drop) and a "we synced recently" skip would be wrong here specifically.
+	local force="${1:-0}"
+
 	# Debounce: the retained homeassistant/status "online" message is
 	# delivered immediately after startup (right after main's own sync) and on
 	# every mosquitto_sub reconnect. Without this guard those would each
 	# trigger a redundant full re-sync. Skip if we synced < 30s ago.
 	local now
 	now=$(date +%s 2>/dev/null || echo 0)
-	if [ -f "$RUNDIR/.last_sync" ]; then
+	if [ "$force" != "1" ] && [ -f "$RUNDIR/.last_sync" ]; then
 		local last
 		last=$(cat "$RUNDIR/.last_sync" 2>/dev/null || echo 0)
 		if [ "$now" -gt 0 ] && [ "$last" -gt 0 ] && [ $((now - last)) -lt 30 ]; then
@@ -383,6 +388,8 @@ do_full_sync() {
 watch_interface() {
 	local interface="$1"
 	while [ ! -f "$RUNDIR/.stop" ]; do
+		local start_ts
+		start_ts=$(date +%s 2>/dev/null || echo 0)
 		# ubus subscribe streams JSON events, one per line-ish.
 		ubus subscribe "$interface" 2>/dev/null | while read -r line; do
 			[ -f "$RUNDIR/.stop" ] && break
@@ -409,9 +416,39 @@ watch_interface() {
 				;;
 			esac
 		done
-		# If ubus subscribe exits (interface gone), wait and retry.
 		[ -f "$RUNDIR/.stop" ] && break
-		sleep 5
+
+		# Distinguish two very different cases that both end up here:
+		#
+		#  1. The interface never existed / doesn't exist yet (typo, not-yet-
+		#     configured radio, or genuinely renamed e.g. after a firmware
+		#     upgrade renumbers phy0->phy1). ubus subscribe exits almost
+		#     instantly every time. Retrying here is expected steady-state
+		#     behavior while we wait for it to show up - it must stay quiet
+		#     and NOT force a full sync every few seconds, or a permanently
+		#     wrong interface name turns into a full-sync spam loop.
+		#
+		#  2. We WERE subscribed and connected for a while, then lost it -
+		#     e.g. hostapd tearing down and recreating the interface after a
+		#     network reconfig, ACS channel reselection, or a radio reset.
+		#     This is the case that can silently miss real assoc/disassoc
+		#     events, so it deserves a loud log line and an immediate full
+		#     sync to close the gap rather than waiting for the fallback
+		#     interval.
+		local end_ts elapsed
+		end_ts=$(date +%s 2>/dev/null || echo 0)
+		elapsed=$((end_ts - start_ts))
+		if [ "$elapsed" -ge 10 ]; then
+			log "ubus subscribe $interface lost connection after ${elapsed}s; reconnecting and forcing a full sync to close any gap" 0
+			# force=1 bypasses the redundant-sync debounce, which would
+			# otherwise silently swallow exactly the sync we need if this
+			# reconnect happens soon after any other sync.
+			do_full_sync 1
+			sleep 5
+		else
+			log "ubus subscribe $interface exited immediately (interface not present?); retrying" 1
+			sleep 15
+		fi
 	done
 }
 

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -182,7 +182,6 @@ ha_seen() {
 		override_icon=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].icon" 2>/dev/null)
 
 		local name="$device_name"
-		[ -n "$AP_NAME" ] && name="${AP_NAME}_${device_name}"
 		[ -n "$override_name" ] && name="$override_name"
 
 		local device_block="\"connections\":[[\"mac\",\"$device\"]]"

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -253,7 +253,14 @@ ha_seen() {
 			body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",${name_field}${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
 		fi
 
-		mqtt_pub "$config_topic" "$body"
+		# Retain the discovery config, not just state. Without this, if HA
+		# is offline/restarting at the exact moment this one-shot config
+		# message is published, HA has no way to learn about the entity's
+		# MQTT subscription again until this script itself restarts (which
+		# forces a fresh republish via reset_registrations). A retained
+		# config lets HA's MQTT integration pick the entity back up on its
+		# own reconnect.
+		mqtt_pub "$config_topic" "$body" 1
 		ok=$?
 	fi
 

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -237,6 +237,23 @@ get_all_online_devices() {
 
 do_full_sync() {
 	# Re-register everything and publish current state for all online devices.
+	#
+	# Debounce: the retained homeassistant/status "online" message is
+	# delivered immediately after startup (right after main's own sync) and on
+	# every mosquitto_sub reconnect. Without this guard those would each
+	# trigger a redundant full re-sync. Skip if we synced < 30s ago.
+	local now
+	now=$(date +%s 2>/dev/null || echo 0)
+	if [ -f "$RUNDIR/.last_sync" ]; then
+		local last
+		last=$(cat "$RUNDIR/.last_sync" 2>/dev/null || echo 0)
+		if [ "$now" -gt 0 ] && [ "$last" -gt 0 ] && [ $((now - last)) -lt 30 ]; then
+			log "Skipping redundant full sync (last was $((now - last))s ago)" 1
+			return 0
+		fi
+	fi
+	echo "$now" > "$RUNDIR/.last_sync" 2>/dev/null
+
 	reset_registrations
 	local seen_file="$RUNDIR/.seen_now"
 	get_all_online_devices | sort -u > "$seen_file"
@@ -342,18 +359,27 @@ cleanup() {
 	log "Stopping..."
 	touch "$RUNDIR/.stop" 2>/dev/null
 	trap '' TERM INT
-	# Kill the whole process group so that grandchildren spawned inside
-	# watcher pipes (ubus subscribe, mosquitto_sub) are terminated too, not
-	# just the direct background jobs.
+	# Kill the direct background jobs (the watcher subshells).
 	kill $CHILD_PIDS 2>/dev/null
-	# Best-effort cleanup of the streaming subprocesses in case they were
-	# reparented (e.g. their parent pipe subshell already exited).
+	# Also kill the streaming grandchildren (ubus subscribe / mosquitto_sub)
+	# spawned inside the watcher pipes. busybox has `pgrep` but NOT `pkill`,
+	# so find PIDs with pgrep and kill them explicitly.
+	local gp
 	for interface in $INTERFACES; do
-		pkill -f "ubus subscribe $interface" 2>/dev/null
+		gp=$(pgrep -f "ubus subscribe $interface" 2>/dev/null)
+		[ -n "$gp" ] && kill $gp 2>/dev/null
 	done
-	pkill -f "mosquitto_sub.*homeassistant/status" 2>/dev/null
+	gp=$(pgrep -f "mosquitto_sub.*homeassistant/status" 2>/dev/null)
+	[ -n "$gp" ] && kill $gp 2>/dev/null
 	sleep 1
+	# Force any survivors.
 	kill -9 $CHILD_PIDS 2>/dev/null
+	for interface in $INTERFACES; do
+		gp=$(pgrep -f "ubus subscribe $interface" 2>/dev/null)
+		[ -n "$gp" ] && kill -9 $gp 2>/dev/null
+	done
+	gp=$(pgrep -f "mosquitto_sub.*homeassistant/status" 2>/dev/null)
+	[ -n "$gp" ] && kill -9 $gp 2>/dev/null
 	exit 0
 }
 
@@ -376,6 +402,12 @@ main() {
 	done
 
 	load_settings
+	# Clear any stale stop-flag left behind by a previous instance's cleanup.
+	# Without this, a single procd restart becomes an infinite crash loop:
+	# the new instance's watcher loops and main loop all test for .stop and
+	# would exit immediately if the previous cleanup's flag were still present.
+	mkdir -p "$RUNDIR"
+	rm -f "$RUNDIR/.stop" 2>/dev/null
 	reset_registrations
 	trap cleanup TERM INT
 
@@ -397,15 +429,20 @@ main() {
 		CHILD_PIDS="$CHILD_PIDS $!"
 	done
 
-	# Main loop: perform periodic fallback full sync if configured.
+	# Main loop. With a fallback interval, periodically re-sync. Without one,
+	# just block so the main process stays in the foreground for procd.
+	#
+	# NOTE: we deliberately do NOT use "sleep N & wait $!" here. When the
+	# background watcher children exit/respawn they deliver SIGCHLD, which
+	# interrupts `wait` and would spin this loop (and destabilise the procd
+	# instance). A plain foreground `sleep` is not affected by SIGCHLD.
 	while [ ! -f "$RUNDIR/.stop" ]; do
 		if [ "$FALLBACK_SYNC_INTERVAL" -gt 0 ] 2>/dev/null; then
 			sleep "$FALLBACK_SYNC_INTERVAL"
 			[ -f "$RUNDIR/.stop" ] && break
 			do_full_sync
 		else
-			sleep 3600 &
-			wait $!
+			sleep 3600
 		fi
 	done
 

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -181,12 +181,25 @@ ha_seen() {
 		local override_icon
 		override_icon=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].icon" 2>/dev/null)
 
-		local name="$device_name"
-		[ -n "$override_name" ] && name="$override_name"
-
+		# Entity name vs device name.
+		#
+		# HA's MQTT discovery uses "has_entity_name": when an entity has BOTH
+		# a device with a name AND its own name, the displayed friendly_name
+		# becomes "<device name> <entity name>". If both are the same string
+		# (as they would be with a params override) that yields an ugly
+		# doubled name ("Presencia Cocina Presencia Cocina").
+		#
+		# So: when a params name override is given, put it on the DEVICE and
+		# emit a JSON null entity name (the entity inherits the device name,
+		# shown once). With no override, use the bare MAC as the entity name
+		# and give the device no name (matching upstream's default).
+		local name_field
 		local device_block="\"connections\":[[\"mac\",\"$device\"]]"
 		if [ -n "$override_name" ]; then
+			name_field="\"name\":null,"
 			device_block="$device_block,\"name\":\"$override_name\""
+		else
+			name_field="\"name\":\"$device_name\","
 		fi
 
 		local icon_field=""
@@ -195,7 +208,7 @@ ha_seen() {
 		local config_topic="homeassistant/device_tracker/${device_slug}/config"
 		local state_topic="homeassistant/device_tracker/${device_slug}/state"
 		local body
-		body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",\"name\":\"$name\",${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
+		body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",${name_field}${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
 
 		mqtt_pub "$config_topic" "$body"
 		ok=$?

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -80,6 +80,18 @@ load_settings() {
 		log "No wifi interfaces found or configured!"
 		exit 1
 	fi
+
+	# Detect ucode (present on OpenWRT 22.03+). When available we build the
+	# MQTT discovery config with a real JSON deep-merge, so ANY key in a
+	# device's params block is honoured (including nested "device" keys such
+	# as manufacturer / model / sw_version). Without ucode we fall back to a
+	# minimal string-built config that supports only name + icon.
+	if command -v ucode >/dev/null 2>&1; then
+		HAS_UCODE=1
+	else
+		HAS_UCODE=0
+		log "ucode not found: params limited to name+icon (install ucode / OpenWRT >= 22.03 for full params)"
+	fi
 }
 
 # ---------------------------------------------------------------------------
@@ -175,40 +187,71 @@ ha_seen() {
 	if ! is_registered "$device_slug"; then
 		mark_registered "$device_slug"
 
-		# Look up per-device overrides for name / icon from params.
-		local override_name
-		override_name=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].name" 2>/dev/null)
-		local override_icon
-		override_icon=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].icon" 2>/dev/null)
-
-		# Entity name vs device name.
-		#
-		# HA's MQTT discovery uses "has_entity_name": when an entity has BOTH
-		# a device with a name AND its own name, the displayed friendly_name
-		# becomes "<device name> <entity name>". If both are the same string
-		# (as they would be with a params override) that yields an ugly
-		# doubled name ("Presencia Cocina Presencia Cocina").
-		#
-		# So: when a params name override is given, put it on the DEVICE and
-		# emit a JSON null entity name (the entity inherits the device name,
-		# shown once). With no override, use the bare MAC as the entity name
-		# and give the device no name (matching upstream's default).
-		local name_field
-		local device_block="\"connections\":[[\"mac\",\"$device\"]]"
-		if [ -n "$override_name" ]; then
-			name_field="\"name\":null,"
-			device_block="$device_block,\"name\":\"$override_name\""
-		else
-			name_field="\"name\":\"$device_name\","
-		fi
-
-		local icon_field=""
-		[ -n "$override_icon" ] && icon_field="\"icon\":\"$override_icon\","
-
 		local config_topic="homeassistant/device_tracker/${device_slug}/config"
 		local state_topic="homeassistant/device_tracker/${device_slug}/state"
 		local body
-		body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",${name_field}${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
+
+		if [ "$HAS_UCODE" = "1" ]; then
+			# Full path: deep-merge the device's entire params block into the
+			# discovery config via ucode, so arbitrary keys work (including
+			# nested device keys: manufacturer, model, sw_version, ...).
+			# Doubling fix: if the device ends up named, the entity name is
+			# set to null so HA shows the device name once.
+			body=$(ucode -l fs \
+				-D CFG="$CONFIG" -D DEV="$device" -D SLUG="$device_slug" \
+				-D LOC="$LOCATION" -D AWAY="$AWAY" -D STYPE="$SOURCE_TYPE" \
+				-e '
+					let fp = fs.open(CFG, "r");
+					let settings = json(fp.read("all")); fp.close();
+					let params = (settings.params && settings.params[DEV]) ? settings.params[DEV] : {};
+					let st = sprintf("homeassistant/device_tracker/%s/state", SLUG);
+					let body = {
+						state_topic: st, json_attributes_topic: st,
+						value_template: "{{ value_json[\x27state\x27] }}",
+						name: replace(DEV, ":", "_"),
+						platform: "device_tracker",
+						payload_home: LOC, payload_not_home: AWAY,
+						source_type: STYPE,
+						device: { connections: [ ["mac", DEV] ] },
+						unique_id: SLUG
+					};
+					function dm(a, b) {
+						for (let k in b) {
+							if (type(a[k]) == "object" && type(b[k]) == "object")
+								dm(a[k], b[k]);
+							else
+								a[k] = b[k];
+						}
+						return a;
+					}
+					dm(body, params);
+					if (!body.device.name && params.name) body.device.name = params.name;
+					if (body.device.name) body.name = null;
+					print(body);
+				' 2>/dev/null)
+		fi
+
+		if [ -z "$body" ]; then
+			# Fallback path (no ucode, or ucode failed): string-built config
+			# supporting only name + icon overrides. Same doubling fix.
+			local override_name
+			override_name=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].name" 2>/dev/null)
+			local override_icon
+			override_icon=$(jsonfilter -i "$CONFIG" -e "@.params['$device'].icon" 2>/dev/null)
+
+			local name_field
+			local device_block="\"connections\":[[\"mac\",\"$device\"]]"
+			if [ -n "$override_name" ]; then
+				name_field="\"name\":null,"
+				device_block="$device_block,\"name\":\"$override_name\""
+			else
+				name_field="\"name\":\"$device_name\","
+			fi
+			local icon_field=""
+			[ -n "$override_icon" ] && icon_field="\"icon\":\"$override_icon\","
+
+			body="{\"state_topic\":\"$state_topic\",\"json_attributes_topic\":\"$state_topic\",\"value_template\":\"{{ value_json['state'] }}\",${name_field}${icon_field}\"platform\":\"device_tracker\",\"payload_home\":\"$LOCATION\",\"payload_not_home\":\"$AWAY\",\"source_type\":\"$SOURCE_TYPE\",\"device\":{$device_block},\"unique_id\":\"$device_slug\"}"
+		fi
 
 		mqtt_pub "$config_topic" "$body"
 		ok=$?


### PR DESCRIPTION
Closes/addresses #85.

### What
Recommends `mosquitto-client-nossl` explicitly everywhere `README-lightweight.md`
names the package, instead of the ambiguous bare `mosquitto-client` name.

### Why
Reported in #85: `mosquitto-client` ships as two alternatives —
`mosquitto-client-nossl` (~144 KiB) and `mosquitto-client-ssl` (~216 KiB) — and
installing the bare name does not reliably resolve to the smaller one. The
reporter's ancient wdr4300 pulled in the SSL variant and hit an out-of-space
install failure as a direct result — exactly the kind of device this shell
implementation exists for.

Verified: `apk info mosquitto-client` returns *both* packages' info, confirming
it's a shared/virtual alias rather than a distinct package. OpenWrt's upstream
Makefile defines the same nossl/ssl alternative split for `opkg` too, so this
affects both package managers, not just apk.

Since the script only ever speaks plain MQTT to the broker (no `mqtts://`/TLS),
the SSL variant buys nothing here.

### Also
Added a note about baking `mosquitto-client-nossl` into a custom image
(imagebuilder / Attended SysUpgrade advanced mode) as the reporter suggested,
for devices where even the install-time overlay write matters.

Checked our own 4 routers running this script — all already had `-nossl`
installed, so no runtime remediation needed there, just the doc fix.