### PR TITLE
shell: ubus-subscribe reliability + away_debounce_seconds (fixes #67, #50)

### DIFF
--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -50,6 +50,15 @@ The behavior mirrors the Python version:
   Home Assistant comes back online, and clears its registration cache when HA
   goes offline (so devices get re-announced via MQTT discovery).
 * An optional **`fallback_sync_interval`** triggers a periodic full sync.
+* An optional **`away_debounce_seconds`** delays publishing "away" after a
+  `disassoc` event by that many seconds, and cancels the pending "away" if
+  the same device re-associates (same or a different interface) before the
+  window elapses. Off by default (`0`, matching the original instant
+  behavior). Useful when a device's Wi-Fi roams between bands/interfaces
+  on the same router, or briefly drops due to power-save/signal, producing
+  a home→away→home flap for every hop — see upstream issues
+  [#67](https://github.com/rmoesbergen/openwrt-ha-device-tracker/issues/67)
+  and [#50](https://github.com/rmoesbergen/openwrt-ha-device-tracker/issues/50).
 
 Registration state (which devices have already had their discovery config
 published) is tracked with marker files under `/var/run/presence-detector/`,
@@ -125,8 +134,8 @@ excludes `presence-detector.settings.json` and
 
 `mqtt_host`, `mqtt_port`, `mqtt_username`, `mqtt_password`,
 `mqtt_retain_state`, `interfaces`, `filter_is_denylist`, `filter`, `params`,
-`ap_name`, `location`, `away`, `fallback_sync_interval`, `source_type`,
-`debug`.
+`ap_name`, `location`, `away`, `fallback_sync_interval`, `away_debounce_seconds`,
+`source_type`, `debug`.
 
 Notes / minor differences:
 

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -301,13 +301,18 @@ get_all_online_devices() {
 do_full_sync() {
 	# Re-register everything and publish current state for all online devices.
 	#
+	# force=1 bypasses the debounce below. Used when we know we may have
+	# missed events (e.g. a watcher just reconnected after an unexpected
+	# drop) and a "we synced recently" skip would be wrong here specifically.
+	local force="${1:-0}"
+
 	# Debounce: the retained homeassistant/status "online" message is
 	# delivered immediately after startup (right after main's own sync) and on
 	# every mosquitto_sub reconnect. Without this guard those would each
 	# trigger a redundant full re-sync. Skip if we synced < 30s ago.
 	local now
 	now=$(date +%s 2>/dev/null || echo 0)
-	if [ -f "$RUNDIR/.last_sync" ]; then
+	if [ "$force" != "1" ] && [ -f "$RUNDIR/.last_sync" ]; then
 		local last
 		last=$(cat "$RUNDIR/.last_sync" 2>/dev/null || echo 0)
 		if [ "$now" -gt 0 ] && [ "$last" -gt 0 ] && [ $((now - last)) -lt 30 ]; then
@@ -383,6 +388,8 @@ do_full_sync() {
 watch_interface() {
 	local interface="$1"
 	while [ ! -f "$RUNDIR/.stop" ]; do
+		local start_ts
+		start_ts=$(date +%s 2>/dev/null || echo 0)
 		# ubus subscribe streams JSON events, one per line-ish.
 		ubus subscribe "$interface" 2>/dev/null | while read -r line; do
 			[ -f "$RUNDIR/.stop" ] && break
@@ -409,9 +416,39 @@ watch_interface() {
 				;;
 			esac
 		done
-		# If ubus subscribe exits (interface gone), wait and retry.
 		[ -f "$RUNDIR/.stop" ] && break
-		sleep 5
+
+		# Distinguish two very different cases that both end up here:
+		#
+		#  1. The interface never existed / doesn't exist yet (typo, not-yet-
+		#     configured radio, or genuinely renamed e.g. after a firmware
+		#     upgrade renumbers phy0->phy1). ubus subscribe exits almost
+		#     instantly every time. Retrying here is expected steady-state
+		#     behavior while we wait for it to show up - it must stay quiet
+		#     and NOT force a full sync every few seconds, or a permanently
+		#     wrong interface name turns into a full-sync spam loop.
+		#
+		#  2. We WERE subscribed and connected for a while, then lost it -
+		#     e.g. hostapd tearing down and recreating the interface after a
+		#     network reconfig, ACS channel reselection, or a radio reset.
+		#     This is the case that can silently miss real assoc/disassoc
+		#     events, so it deserves a loud log line and an immediate full
+		#     sync to close the gap rather than waiting for the fallback
+		#     interval.
+		local end_ts elapsed
+		end_ts=$(date +%s 2>/dev/null || echo 0)
+		elapsed=$((end_ts - start_ts))
+		if [ "$elapsed" -ge 10 ]; then
+			log "ubus subscribe $interface lost connection after ${elapsed}s; reconnecting and forcing a full sync to close any gap" 0
+			# force=1 bypasses the redundant-sync debounce, which would
+			# otherwise silently swallow exactly the sync we need if this
+			# reconnect happens soon after any other sync.
+			do_full_sync 1
+			sleep 5
+		else
+			log "ubus subscribe $interface exited immediately (interface not present?); retrying" 1
+			sleep 15
+		fi
 	done
 }
 

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -63,6 +63,7 @@ load_settings() {
 	LOCATION=$(get_setting '@.location' 'home')
 	AWAY=$(get_setting '@.away' 'not_home')
 	FALLBACK_SYNC_INTERVAL=$(get_setting '@.fallback_sync_interval' '0')
+	AWAY_DEBOUNCE_SECONDS=$(get_setting '@.away_debounce_seconds' '0')
 	SOURCE_TYPE=$(get_setting '@.source_type' 'router')
 	DEBUG=$(get_setting '@.debug' 'false')
 	[ "$DEBUG" = "true" ] && DEBUG=1 || DEBUG=0
@@ -141,6 +142,33 @@ mark_registered() {
 }
 
 # ---------------------------------------------------------------------------
+# Away-debounce state
+# ---------------------------------------------------------------------------
+# A device roaming between interfaces/bands on the same router (or briefly
+# dropping due to power-save/signal) produces a disassoc immediately followed
+# by a fresh assoc, often within well under a second. Without debouncing that
+# publishes a home->away->home flap to HA for every such hop (see upstream
+# issues #67 and #50). When AWAY_DEBOUNCE_SECONDS > 0, a disassoc doesn't
+# publish "away" right away - it records a pending marker (named after the
+# device slug, same identity ha_seen already uses) and a background check
+# fires after the debounce window to publish "away" only if the marker is
+# still there. Any assoc for that device in the meantime removes the marker
+# first, so the delayed check finds it gone and does nothing - no flap.
+
+mark_pending_away() {
+	# mark_pending_away <device_slug>
+	echo "$1" > "$RUNDIR/$1.pending_away" 2>/dev/null
+}
+
+clear_pending_away() {
+	rm -f "$RUNDIR/$1.pending_away" 2>/dev/null
+}
+
+is_pending_away() {
+	[ -f "$RUNDIR/$1.pending_away" ]
+}
+
+# ---------------------------------------------------------------------------
 # Device filtering
 # ---------------------------------------------------------------------------
 
@@ -164,6 +192,18 @@ should_handle_device() {
 	[ "$FILTER_IS_DENYLIST" = "true" ] && return 0 || return 1
 }
 
+# device_slug: mac with ':' -> '_', optionally prefixed by ap_name. Shared by
+# ha_seen and the away-debounce markers so both key off the same identity.
+device_slug() {
+	local device_name
+	device_name=$(echo "$1" | tr ':' '_')
+	if [ -n "$AP_NAME" ]; then
+		echo "${AP_NAME}_${device_name}"
+	else
+		echo "$device_name"
+	fi
+}
+
 # ---------------------------------------------------------------------------
 # JSON escaping for params passthrough
 # ---------------------------------------------------------------------------
@@ -174,13 +214,10 @@ ha_seen() {
 	local device="$1"
 	local seen="$2"
 
-	# device_slug: mac with ':' -> '_', optionally prefixed by ap_name
 	local device_name
+	local device_slug
 	device_name=$(echo "$device" | tr ':' '_')
-	local device_slug="$device_name"
-	if [ -n "$AP_NAME" ]; then
-		device_slug="${AP_NAME}_${device_name}"
-	fi
+	device_slug=$(device_slug "$device")
 
 	local ok=0
 
@@ -400,6 +437,11 @@ watch_interface() {
 					head -n1 | cut -d'"' -f4 | tr 'A-Z' 'a-z')
 				[ -z "$mac" ] && continue
 				if should_handle_device "$mac"; then
+					# Cancel any pending debounced "away" for this device -
+					# it just reappeared (same interface, another interface
+					# on this router, or reconnected after a brief drop), so
+					# the delayed check below must find nothing and no-op.
+					clear_pending_away "$(device_slug "$mac")"
 					log "Device $mac on $interface is now at $LOCATION" 1
 					ha_seen "$mac" 1
 				fi
@@ -410,8 +452,36 @@ watch_interface() {
 					head -n1 | cut -d'"' -f4 | tr 'A-Z' 'a-z')
 				[ -z "$mac" ] && continue
 				if should_handle_device "$mac"; then
-					log "Device $mac on $interface is now away" 1
-					ha_seen "$mac" 0
+					if [ "$AWAY_DEBOUNCE_SECONDS" -gt 0 ] 2>/dev/null; then
+						local slug
+						slug=$(device_slug "$mac")
+						mark_pending_away "$slug"
+						log "Device $mac on $interface disassociated; debouncing ${AWAY_DEBOUNCE_SECONDS}s before marking away" 1
+						(
+							sleep "$AWAY_DEBOUNCE_SECONDS"
+							# Don't act past shutdown, and only publish away
+							# if nothing re-marked this device home (via
+							# clear_pending_away) while we were sleeping.
+							if [ ! -f "$RUNDIR/.stop" ] && is_pending_away "$slug"; then
+								clear_pending_away "$slug"
+								log "Device $mac is now away (debounced)" 1
+								ha_seen "$mac" 0
+							fi
+						) &
+						# Record the PID (append-only, never pruned at
+						# runtime - a few bytes per roam event is negligible
+						# on tmpfs) so cleanup() can reap it precisely by
+						# PID. A plain `sleep` has nothing in its own
+						# command line to distinguish it, so a pgrep -f name
+						# match here would be exactly the kind of overbroad
+						# match that self-matches unrelated ash processes;
+						# killing a PID that already exited is a silent
+						# no-op, so a stale entry is harmless.
+						echo "$!" >> "$RUNDIR/.debounce_pids" 2>/dev/null
+					else
+						log "Device $mac on $interface is now away" 1
+						ha_seen "$mac" 0
+					fi
 				fi
 				;;
 			esac
@@ -499,6 +569,14 @@ cleanup() {
 	done
 	gp=$(pgrep -f "mosquitto_sub.*homeassistant/status" 2>/dev/null)
 	[ -n "$gp" ] && kill $gp 2>/dev/null
+	# Any in-flight away-debounce sleeps (see watch_interface). Each already
+	# re-checks $RUNDIR/.stop before acting, so this is belt-and-suspenders
+	# against a message being published after we've stopped. Killed by PID
+	# (not name match - see the comment where these PIDs are recorded);
+	# killing an already-exited PID is a silent no-op.
+	if [ -f "$RUNDIR/.debounce_pids" ]; then
+		kill $(cat "$RUNDIR/.debounce_pids" 2>/dev/null) 2>/dev/null
+	fi
 	sleep 1
 	kill -9 $CHILD_PIDS 2>/dev/null
 	for interface in $INTERFACES; do
@@ -507,6 +585,10 @@ cleanup() {
 	done
 	gp=$(pgrep -f "mosquitto_sub.*homeassistant/status" 2>/dev/null)
 	[ -n "$gp" ] && kill -9 $gp 2>/dev/null
+	if [ -f "$RUNDIR/.debounce_pids" ]; then
+		kill -9 $(cat "$RUNDIR/.debounce_pids" 2>/dev/null) 2>/dev/null
+		rm -f "$RUNDIR/.debounce_pids" 2>/dev/null
+	fi
 	exit 0
 }
 
@@ -535,6 +617,10 @@ main() {
 	# would exit immediately if the previous cleanup's flag were still present.
 	mkdir -p "$RUNDIR"
 	rm -f "$RUNDIR/.stop" 2>/dev/null
+	# Same idea for the away-debounce PID list and any pending markers: a
+	# hard kill (kill -9 on the main process itself) bypasses cleanup(), so
+	# don't inherit a previous instance's now-meaningless PIDs/markers.
+	rm -f "$RUNDIR/.debounce_pids" "$RUNDIR"/*.pending_away 2>/dev/null
 	reset_registrations
 	trap cleanup TERM INT
 


### PR DESCRIPTION
Replaces #88, which had my old branch's full squash-merged history
duplicated as separate commits - this one is rebased clean on current
`main` with just the two relevant commits.

Addresses #67 and #50.

### Commit 1: ubus-subscribe reliability
`ubus subscribe <interface>` can be silently dropped (e.g. hostapd
tearing down and recreating the interface after a network reconfig or
ACS channel reselection) without any error - the watcher just exits and
quietly retries, potentially missing real assoc/disassoc events in the
gap. This adds elapsed-time tracking: a subscription that was alive
≥10s before dying is treated as a genuine transient drop (logged loudly,
triggers an immediate full sync to close the gap); one that dies
almost instantly is treated as "interface not present yet" (quiet
retry, unchanged from before - forcing a sync on every attempt here
would spam a full-sync loop if an interface name is ever wrong).

Found and fixed this after a real incident: a WAN blip on one of my
routers cascaded into hostapd restarting both radios, silently killing
the subscription, and a device that came home during the gap stayed
`not_home` in Home Assistant for hours.

### Commit 2: away_debounce_seconds
New optional setting (default `0`, off/instant, same as today). When
`> 0`, a `disassoc` doesn't publish "away" immediately - it records a
pending marker and a background check fires after the debounce window,
publishing "away" only if the marker is still there. Any `assoc` for
that device in the meantime (same interface, another interface on the
same router, or a genuine fast reconnect) clears the marker first, so
the delayed check finds nothing and no-ops. Fixes the home→away→home
flap described in #67 (band/interface roaming) and requested in #50
(reconnect grace period) - confirmed the same flap happening on my own
routers' live logs, not just in theory.

### Verified
- Isolated logic tests (quick reassoc / genuine disconnect / rapid
  multi-flap) all pass.
- Re-ran the same scenarios on live router hardware using the actual
  shipped code path verbatim, including a shutdown-safety case
  (`.stop` mid-debounce correctly suppresses the pending publish).
- Deployed to all 4 of my production routers, all confirmed running
  post-restart, SHA-matched, no regressions.