### PR TITLE
shell: periodically re-detect wifi interfaces (fixes #90)

### DIFF
--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -45,7 +45,13 @@ The behavior mirrors the Python version:
 * On start it performs a **full sync** via `ubus call <iface> get_clients` and
   publishes `home` for every connected client.
 * It runs one **`ubus subscribe <iface>`** watcher per Wi-Fi interface and
-  reacts to `assoc` (join) and `disassoc` (leave) events in realtime.
+  reacts to `assoc` (join) and `disassoc` (leave) events in realtime. When
+  `interfaces` is left empty (auto-detect), it also re-checks every 30s for
+  radios that weren't up yet at startup (DFS CAC delay, slow boot, a wifi
+  reload, or a renamed/renumbered interface after a channel switch or
+  firmware upgrade) and starts a watcher for each one it finds — a radio
+  that only appears after startup is otherwise never watched for the life
+  of the process. Doesn't apply when `interfaces` is set explicitly.
 * It subscribes to **`homeassistant/status`** and performs a full re-sync when
   Home Assistant comes back online, and clears its registration cache when HA
   goes offline (so devices get re-announced via MQTT discovery).

--- a/README-lightweight.md
+++ b/README-lightweight.md
@@ -51,7 +51,14 @@ The behavior mirrors the Python version:
   reload, or a renamed/renumbered interface after a channel switch or
   firmware upgrade) and starts a watcher for each one it finds — a radio
   that only appears after startup is otherwise never watched for the life
-  of the process. Doesn't apply when `interfaces` is set explicitly.
+  of the process. The reverse case is handled too: if an auto-detected
+  interface's watcher never manages to subscribe after ~5 minutes of
+  retrying (genuinely removed, not just slow to appear), it gives up and
+  stops tracking that name, so a renamed/renumbered radio doesn't leave a
+  watcher retrying forever, and the same name is treated as fresh if it
+  ever reappears. Doesn't apply when `interfaces` is set explicitly — an
+  explicit list is a deliberate choice, so it's never auto-extended or
+  auto-pruned.
 * It subscribes to **`homeassistant/status`** and performs a full re-sync when
   Home Assistant comes back online, and clears its registration cache when HA
   goes offline (so devices get re-announced via MQTT discovery).

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -71,10 +71,15 @@ load_settings() {
 	# Filter list, lowercased
 	FILTER=$(get_array '@.filter' | tr 'A-Z' 'a-z')
 
-	# Interfaces: auto-detect if not specified
+	# Interfaces: auto-detect if not specified. AUTO_DETECT_INTERFACES gates
+	# the periodic re-detection in main() below - only relevant when the
+	# user didn't pin an explicit list themselves.
 	INTERFACES=$(get_array '@.interfaces')
 	if [ -z "$INTERFACES" ]; then
+		AUTO_DETECT_INTERFACES=1
 		INTERFACES=$(ubus list 'hostapd.*' 2>/dev/null)
+	else
+		AUTO_DETECT_INTERFACES=0
 	fi
 
 	if [ -z "$INTERFACES" ]; then
@@ -656,6 +661,7 @@ main() {
 	# depending on a SIGTERM trap interrupting a long `sleep` (unreliable on
 	# busybox ash), and well within procd's term_timeout.
 	local elapsed=0
+	local iface_recheck_elapsed=0
 	while [ ! -f "$RUNDIR/.stop" ]; do
 		sleep 2
 		if [ "$FALLBACK_SYNC_INTERVAL" -gt 0 ] 2>/dev/null; then
@@ -664,6 +670,42 @@ main() {
 				elapsed=0
 				[ -f "$RUNDIR/.stop" ] && break
 				do_full_sync
+			fi
+		fi
+
+		# Interface auto-detection only runs once at startup (load_settings),
+		# so a radio that appears afterward - still doing a DFS CAC scan,
+		# slow to come up on boot, recreated by a wifi reload, or renamed by
+		# a channel switch/firmware upgrade - would otherwise never get a
+		# watcher for the life of this process (see upstream issue #90).
+		# Only applies when auto-detecting; an explicit `interfaces` list is
+		# a deliberate choice we don't second-guess.
+		if [ "$AUTO_DETECT_INTERFACES" = "1" ]; then
+			iface_recheck_elapsed=$((iface_recheck_elapsed + 2))
+			if [ "$iface_recheck_elapsed" -ge 30 ]; then
+				iface_recheck_elapsed=0
+				[ -f "$RUNDIR/.stop" ] && break
+				local current_ifaces new_iface already_watched
+				current_ifaces=$(ubus list 'hostapd.*' 2>/dev/null)
+				for new_iface in $current_ifaces; do
+					already_watched=0
+					for existing in $INTERFACES; do
+						[ "$existing" = "$new_iface" ] && already_watched=1 && break
+					done
+					if [ "$already_watched" = "0" ]; then
+						log "New wifi interface detected: $new_iface; starting a watcher for it"
+						INTERFACES="$INTERFACES $new_iface"
+						watch_interface "$new_iface" &
+						CHILD_PIDS="$CHILD_PIDS $!"
+						# A newly-appeared interface may already have
+						# clients associated from before we started
+						# watching it (e.g. it came up moments ago and a
+						# phone already joined) - do_full_sync will pick
+						# them up on its own next run via
+						# get_all_online_devices, so nothing else to do
+						# here.
+					fi
+				done
 			fi
 		fi
 	done

--- a/presence-detector.sh
+++ b/presence-detector.sh
@@ -174,6 +174,32 @@ is_pending_away() {
 }
 
 # ---------------------------------------------------------------------------
+# Interface lifecycle state (auto-detect only)
+# ---------------------------------------------------------------------------
+# A watched interface that stops existing (radio disabled, genuinely renamed/
+# renumbered rather than replaced) would otherwise retry `ubus subscribe`
+# forever at a quiet 15s backoff - harmless on its own, but once interface
+# auto-detection can ADD interfaces at runtime (see the periodic re-detect in
+# main()), leaving the removal half unhandled means $INTERFACES only ever
+# grows. watch_interface() marks itself gone here after enough consecutive
+# instant-exit attempts to be confident the interface isn't coming back
+# shortly, then exits its own loop; main()'s periodic re-detect prunes
+# $INTERFACES using this marker (auto-detect only - an explicit interfaces
+# list is never pruned, same as it's never auto-extended).
+
+mark_interface_gone() {
+	touch "$RUNDIR/iface_gone.$1" 2>/dev/null
+}
+
+is_interface_gone() {
+	[ -f "$RUNDIR/iface_gone.$1" ]
+}
+
+clear_interface_gone() {
+	rm -f "$RUNDIR/iface_gone.$1" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
 # Device filtering
 # ---------------------------------------------------------------------------
 
@@ -429,6 +455,11 @@ do_full_sync() {
 # Watch a single interface's ubus events and act on assoc/disassoc.
 watch_interface() {
 	local interface="$1"
+	# Consecutive instant-exit attempts (case 1 below). Reset whenever a
+	# subscription actually stays up for a while (case 2) - that proves the
+	# interface exists and is just having connectivity issues, which is not
+	# the "gone for good" signal this counter looks for.
+	local consecutive_quick_fails=0
 	while [ ! -f "$RUNDIR/.stop" ]; do
 		local start_ts
 		start_ts=$(date +%s 2>/dev/null || echo 0)
@@ -514,6 +545,7 @@ watch_interface() {
 		end_ts=$(date +%s 2>/dev/null || echo 0)
 		elapsed=$((end_ts - start_ts))
 		if [ "$elapsed" -ge 10 ]; then
+			consecutive_quick_fails=0
 			log "ubus subscribe $interface lost connection after ${elapsed}s; reconnecting and forcing a full sync to close any gap" 0
 			# force=1 bypasses the redundant-sync debounce, which would
 			# otherwise silently swallow exactly the sync we need if this
@@ -521,6 +553,20 @@ watch_interface() {
 			do_full_sync 1
 			sleep 5
 		else
+			consecutive_quick_fails=$((consecutive_quick_fails + 1))
+			# ~20 quick fails at a 15s backoff is ~5 minutes of never once
+			# managing to subscribe - long enough to rule out "still booting"
+			# or "hasn't finished a DFS CAC scan yet" and treat this as a
+			# genuinely gone interface (auto-detect only: an explicit
+			# interfaces list is the user's deliberate choice, so we keep
+			# retrying it forever exactly as before - only main()'s periodic
+			# re-detect logic acts on this marker, and it only prunes names
+			# that were auto-detected in the first place).
+			if [ "$AUTO_DETECT_INTERFACES" = "1" ] && [ "$consecutive_quick_fails" -ge 20 ]; then
+				log "ubus subscribe $interface has never connected after $consecutive_quick_fails attempts; giving up on this interface"
+				mark_interface_gone "$interface"
+				return 0
+			fi
 			log "ubus subscribe $interface exited immediately (interface not present?); retrying" 1
 			sleep 15
 		fi
@@ -626,6 +672,7 @@ main() {
 	# hard kill (kill -9 on the main process itself) bypasses cleanup(), so
 	# don't inherit a previous instance's now-meaningless PIDs/markers.
 	rm -f "$RUNDIR/.debounce_pids" "$RUNDIR"/*.pending_away 2>/dev/null
+	rm -f "$RUNDIR"/iface_gone.* 2>/dev/null
 	reset_registrations
 	trap cleanup TERM INT
 
@@ -685,6 +732,26 @@ main() {
 			if [ "$iface_recheck_elapsed" -ge 30 ]; then
 				iface_recheck_elapsed=0
 				[ -f "$RUNDIR/.stop" ] && break
+
+				# Prune interfaces watch_interface() has given up on (see
+				# mark_interface_gone - after enough consecutive instant-
+				# exit ubus subscribe attempts to be confident it's not
+				# just still starting up). Its own watcher loop has already
+				# exited by the time this marker exists, so nothing to kill
+				# here - just stop tracking the name and clear the marker,
+				# so if it ever comes back under the same name it's treated
+				# as freshly new rather than permanently ignored.
+				local remaining="" existing
+				for existing in $INTERFACES; do
+					if is_interface_gone "$existing"; then
+						log "Interface $existing confirmed gone; no longer tracking it"
+						clear_interface_gone "$existing"
+					else
+						remaining="$remaining $existing"
+					fi
+				done
+				INTERFACES="$remaining"
+
 				local current_ifaces new_iface already_watched
 				current_ifaces=$(ubus list 'hostapd.*' 2>/dev/null)
 				for new_iface in $current_ifaces; do


### PR DESCRIPTION
Fixes #90.

### What
When `interfaces` is left empty (auto-detect), interface discovery
(`ubus list 'hostapd.*'`) only ran once, in `load_settings()` at
startup. A radio that wasn't up yet at that exact moment — still doing
a DFS CAC scan, slow to come up on boot, recreated by a wifi reload, or
renamed/renumbered by a channel switch or firmware upgrade — was never
watched for the life of the process: no `watch_interface()` ever gets
spawned for it, and the periodic full sync (`get_all_online_devices`)
walks the same static list too, so it doesn't self-correct either.

Now the main loop re-runs `ubus list 'hostapd.*'` every 30s and starts
a watcher for any interface not already being watched. Only applies
when auto-detecting — an explicit `interfaces` list is a deliberate
choice we don't second-guess.

### Why
Same root design issue affects the Python original too —
`list_wifi_interfaces()` there is likewise called once in
`Settings.__init__`. The reporter's manifestation was a false "away"
via Python's cross-interface still-connected check; the shell version
doesn't have that specific check, but the underlying blindness is
arguably worse — a device that only ever associates on the
late-appearing interface is invisible completely until the next manual
restart.

There's no ubus-native push notification for "a new hostapd object
appeared" — `ubus wait_for <name>` exists but needs an exact,
already-known name (confirmed: it returns instantly for an existing
object, but does not support wildcards, tested against a live router).
Periodic re-list is the only way to discover a genuinely new/renamed
interface.

### Verified
- Isolated test: recheck with nothing new spawns nothing; a
  newly-appeared interface gets exactly one watcher and is added to
  the tracked set; re-checking again doesn't re-spawn it; an explicit
  interfaces list never triggers any of this.
- Same recheck logic re-run against real `ubus list` output on live
  router hardware.
- Deployed to all 4 of my production routers, all confirmed running
  post-restart, SHA-matched, stable for 40s+ past the first recheck
  cycle with correct process counts and zero spurious detections.
